### PR TITLE
Add municipality filtering support and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,61 @@
 
 Laravel package to consume the [Tunisian Municipality API](https://tn-municipality-api.vercel.app/).
 
+## Installation
+
+```bash
+composer require tunisian-municipality/api
+```
+
+If your Laravel version does not support package auto-discovery, register the service provider and facade:
+
+```php
+// config/app.php
+'providers' => [
+    TunisianMunicipality\TunisianMunicipalityServiceProvider::class,
+],
+
+'aliases' => [
+    'TunisianMunicipality' => TunisianMunicipality\Facades\TunisianMunicipality::class,
+],
+```
+
 ## Usage
 
-Register the service provider (for Laravel versions prior to auto-discovery) and use the facade:
+### Basic example
 
 ```php
 use TunisianMunicipality\Facades\TunisianMunicipality;
 
 $municipalities = TunisianMunicipality::getMunicipalities();
+```
+
+### Filtering results
+
+Pass an associative array of query parameters to `getMunicipalities` to filter the results returned from the API:
+
+```php
+// Retrieve municipalities that match the provided filters
+$filtered = TunisianMunicipality::getMunicipalities([
+    'name' => 'Tunis',    // filter by municipality name
+    // other supported filters can be passed here
+]);
+```
+
+### Custom client or base URL
+
+```php
+use GuzzleHttp\Client;
+use TunisianMunicipality\TunisianMunicipality as MunicipalityClient;
+
+$client = new MunicipalityClient(new Client(), 'https://tn-municipality-api.vercel.app');
+$all = $client->getMunicipalities();
+```
+
+## Testing
+
+Run the package tests with PHPUnit:
+
+```bash
+composer test
 ```

--- a/src/TunisianMunicipality.php
+++ b/src/TunisianMunicipality.php
@@ -15,9 +15,16 @@ class TunisianMunicipality
         $this->baseUrl = rtrim($baseUrl, '/');
     }
 
-    public function getMunicipalities(): array
+    public function getMunicipalities(array $filters = []): array
     {
-        $response = $this->client->get($this->baseUrl . '/municipalities');
+        $url = $this->baseUrl . '/municipalities';
+
+        if (!empty($filters)) {
+            $url .= '?' . http_build_query($filters);
+        }
+
+        $response = $this->client->get($url);
+
         return json_decode((string) $response->getBody(), true);
     }
 }

--- a/tests/TunisianMunicipalityTest.php
+++ b/tests/TunisianMunicipalityTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Middleware;
 use PHPUnit\Framework\TestCase;
 use TunisianMunicipality\TunisianMunicipality;
 
@@ -26,5 +27,28 @@ class TunisianMunicipalityTest extends TestCase
 
         $this->assertIsArray($response);
         $this->assertSame('Test', $response[0]['name']);
+    }
+
+    public function test_get_municipalities_with_filters_adds_query_parameters(): void
+    {
+        $container = [];
+        $history = Middleware::history($container);
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([]))
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+
+        $client = new Client(['handler' => $handlerStack]);
+
+        $api = new TunisianMunicipality($client);
+
+        $api->getMunicipalities(['name' => 'Tunis']);
+
+        $this->assertNotEmpty($container);
+        $request = $container[0]['request'];
+        $this->assertSame('name=Tunis', $request->getUri()->getQuery());
     }
 }


### PR DESCRIPTION
## Summary
- allow passing query parameters to `getMunicipalities` for filtered results
- document package installation, usage and filtering
- test query string handling

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68988482c98883258f377bb197348d00