### PR TITLE
Return collections and update API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tunisian Municipality API
 
-Laravel package to consume the [Tunisian Municipality API](https://tn-municipality-api.vercel.app/).
+Laravel package to consume the [Tunisian Municipality API](https://tn-municipality-api.vercel.app/api).
 
 ## Installation
 
@@ -13,11 +13,11 @@ If your Laravel version does not support package auto-discovery, register the se
 ```php
 // config/app.php
 'providers' => [
-    TunisianMunicipality\TunisianMunicipalityServiceProvider::class,
+    TunisianMunicipality\\TunisianMunicipalityServiceProvider::class,
 ],
 
 'aliases' => [
-    'TunisianMunicipality' => TunisianMunicipality\Facades\TunisianMunicipality::class,
+    'TunisianMunicipality' => TunisianMunicipality\\Facades\\TunisianMunicipality::class,
 ],
 ```
 
@@ -26,9 +26,10 @@ If your Laravel version does not support package auto-discovery, register the se
 ### Basic example
 
 ```php
-use TunisianMunicipality\Facades\TunisianMunicipality;
+use TunisianMunicipality\\Facades\\TunisianMunicipality;
 
 $municipalities = TunisianMunicipality::getMunicipalities();
+// $municipalities is an Illuminate\\Support\\Collection instance
 ```
 
 ### Filtering results
@@ -46,10 +47,10 @@ $filtered = TunisianMunicipality::getMunicipalities([
 ### Custom client or base URL
 
 ```php
-use GuzzleHttp\Client;
-use TunisianMunicipality\TunisianMunicipality as MunicipalityClient;
+use GuzzleHttp\\Client;
+use TunisianMunicipality\\TunisianMunicipality as MunicipalityClient;
 
-$client = new MunicipalityClient(new Client(), 'https://tn-municipality-api.vercel.app');
+$client = new MunicipalityClient(new Client(), 'https://tn-municipality-api.vercel.app/api');
 $all = $client->getMunicipalities();
 ```
 

--- a/src/TunisianMunicipality.php
+++ b/src/TunisianMunicipality.php
@@ -3,19 +3,20 @@
 namespace TunisianMunicipality;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
 
 class TunisianMunicipality
 {
     protected Client $client;
     protected string $baseUrl;
 
-    public function __construct(?Client $client = null, string $baseUrl = 'https://tn-municipality-api.vercel.app')
+    public function __construct(?Client $client = null, string $baseUrl = 'https://tn-municipality-api.vercel.app/api')
     {
         $this->client = $client ?: new Client();
         $this->baseUrl = rtrim($baseUrl, '/');
     }
 
-    public function getMunicipalities(array $filters = []): array
+    public function getMunicipalities(array $filters = []): Collection
     {
         $url = $this->baseUrl . '/municipalities';
 
@@ -25,6 +26,6 @@ class TunisianMunicipality
 
         $response = $this->client->get($url);
 
-        return json_decode((string) $response->getBody(), true);
+        return new Collection(json_decode((string) $response->getBody(), true));
     }
 }

--- a/tests/TunisianMunicipalityTest.php
+++ b/tests/TunisianMunicipalityTest.php
@@ -7,12 +7,13 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Middleware;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use TunisianMunicipality\TunisianMunicipality;
 
 class TunisianMunicipalityTest extends TestCase
 {
-    public function test_get_municipalities_returns_array(): void
+    public function test_get_municipalities_returns_collection(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode([["id" => 1, "name" => "Test"]]))
@@ -25,8 +26,8 @@ class TunisianMunicipalityTest extends TestCase
 
         $response = $api->getMunicipalities();
 
-        $this->assertIsArray($response);
-        $this->assertSame('Test', $response[0]['name']);
+        $this->assertInstanceOf(Collection::class, $response);
+        $this->assertSame('Test', $response->first()['name']);
     }
 
     public function test_get_municipalities_with_filters_adds_query_parameters(): void


### PR DESCRIPTION
## Summary
- Default API base URL now points to `/api`
- `getMunicipalities` returns an `Illuminate\Support\Collection`
- Document new collection return type and updated base URL in README

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68988d483a888325975210f336481910